### PR TITLE
Use strptime to parse date as well

### DIFF
--- a/lib/total_in/typecaster.rb
+++ b/lib/total_in/typecaster.rb
@@ -10,7 +10,7 @@ module TotalIn
       {
         integer: ->(value) { value.to_i },
         time: ->(value) { Time.strptime(value, "%Y%m%d%H%M%S%N") },
-        date: ->(value) { Date.parse(value) },
+        date: ->(value) { Date.strptime(value, "%Y%m%d") },
         string: ->(value) { value unless value.match(/\A0+\Z/) }
       }
     end


### PR DESCRIPTION
Using `Date.parse` does work with the given format, but I'm a bit worried about weird edge cases, so I thought it'd be better to be stricter about this. Also it's more consistent.
