### PR TITLE
Simplify iteration of lines using each_with_object

### DIFF
--- a/lib/total_in/document.rb
+++ b/lib/total_in/document.rb
@@ -92,10 +92,6 @@ module TotalIn
       attribute :postal_code
       attribute :city
       attribute :country_code
-
-      def self.add_to_contexts contexts
-        contexts.move_to_or_add_to_parent self, Transaction
-      end
     end
 
     class SenderAccount
@@ -108,10 +104,6 @@ module TotalIn
       attribute :account_number
       attribute :origin_code
       attribute :company_organization_number
-
-      def self.add_to_contexts contexts
-        contexts.move_to_or_add_to_parent self, Transaction
-      end
     end
 
     class International

--- a/lib/total_in/line_processors.rb
+++ b/lib/total_in/line_processors.rb
@@ -77,16 +77,16 @@ module TotalIn
     }
 
     class WithTargetClass
+      attr_reader :target_class
+
       def initialize target_class
         @target_class = target_class
       end
-
-      attr_reader :target_class
     end
 
     class Names < WithTargetClass
       def call line, contexts
-        contexts = target_class.add_to_contexts contexts
+        contexts.move_to_or_add_to_parent self.target_class, Document::Transaction
 
         contexts.current.name = line.values.join " "
 
@@ -94,10 +94,9 @@ module TotalIn
       end
     end
 
-
     class Addresses < WithTargetClass
       def call line, contexts
-        contexts = target_class.add_to_contexts contexts
+        contexts.move_to_or_add_to_parent self.target_class, Document::Transaction
 
         contexts.current.address = line.values.join " "
 
@@ -107,7 +106,7 @@ module TotalIn
 
     class Locality < WithTargetClass
       def call line, contexts
-        contexts = target_class.add_to_contexts contexts
+        contexts.move_to_or_add_to_parent self.target_class, Document::Transaction
 
         contexts.current.assign_attributes line.attributes
 
@@ -116,7 +115,7 @@ module TotalIn
     end
 
     SenderAccount = ->(line, contexts) {
-      contexts = Document::SenderAccount.add_to_contexts contexts
+      contexts.move_to_or_add_to_parent Document::SenderAccount, Document::Transaction
 
       contexts.current.assign_attributes line.attributes
 
@@ -124,9 +123,7 @@ module TotalIn
     }
 
     International = ->(line, contexts) {
-      until contexts.current.kind_of?(Document::Transaction)
-        contexts.move_up
-      end
+      contexts.move_to Document::Transaction
 
       international = Document::International.new line.attributes
 

--- a/lib/total_in/parser.rb
+++ b/lib/total_in/parser.rb
@@ -16,31 +16,24 @@ module TotalIn
     end
 
     def result
-      parse_lines(Contexts.new).result
+      contexts = self.lines.each_with_object(Contexts.new) do |line, c|
+        parse_line line, c
+      end
+
+      contexts.result
     end
 
     protected
 
     def lines
-      @lines ||= file.each_line
+      file.each_line
     end
 
     private
 
     def validate_file_format
-      validator = FileFormatValidator.new first_line
-      raise InvalidFileFormatError.new(validator.errors.join(", ")) unless validator.valid?
-    end
-
-    def parse_lines contexts
-      begin
-        loop do
-          contexts = parse_line self.lines.next, contexts
-        end
-        contexts
-      rescue StopIteration
-        self.lines.rewind # Ensure we do not bomb out when calling result multiple times
-        contexts
+      unless FileFormatValidator.new(first_line).valid?
+        raise InvalidFileFormatError.new validator.errors.join(", ")
       end
     end
 


### PR DESCRIPTION
Removes the awkward loop construct in favor for a simple transform.
We also remove some knowledge from the data objects pushing it to the processor functions instead.
